### PR TITLE
update to build for Linux from source

### DIFF
--- a/wxpython-phoenix/build.sh
+++ b/wxpython-phoenix/build.sh
@@ -1,6 +1,49 @@
 #!/bin/bash
 
-pip install -U --pre \
-        --trusted-host wxpython.org \
-        -f http://wxpython.org/Phoenix/snapshot-builds/ \
-        wxPython_Phoenix
+## install wxPython_Phoenix from snapshot build:
+
+pkgname='wxPython_Phoenix'
+pip_opts='--pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds/'
+
+osname=`uname -s`
+
+## for Darwin, we can just do install on the fetched binary wheel,
+if [[ "$osname" == 'Darwin' ]] ; then
+    pip install -U $pip_opts $pkgname
+
+elif [[ "$osname" == 'Linux' ]] ; then
+
+    ## for Linux, this fetched a source tarball that we now need to build.
+    ##
+    ## this follows build instructions using Fedora,
+    ## which need the following packages installed:
+    ##
+    ## (sudo dnf/yum install)
+    ##     dpkg  python-devel
+    ##     webkitgtk webkitgtk-devel
+    ##     freeglut freeglut-devel
+    ##     libnotify libnotify-devel
+    ##     libtiff libtiff-devel
+    ##     libjpeg libjpeg-devel
+    ##     SDL SDL-devel
+    ##     gstreamermm gstreamermm-devel
+
+    pip download $pip_opts $pkgname
+
+    dirname=`ls | grep wxPython_Phoenix | sed 's/.tar.gz//g'`
+    tar xvzf $dirname.tar.gz
+    cd $dirname
+
+    # custom complier flags and libs from gstreamer:
+    export GST_LIBS=`pkg-config gstreamer-0.10 --libs`
+    export GST_CFLAGS=`pkg-config gstreamer-0.10 --cflags`
+
+    # we need to make the right sure libiconv is found for wxrc
+    python build.py dox etg --nodoc sip
+    python build.py build --extra_make='LIBS=-L$CONDA_PREFIX/lib -liconv'
+    python build.py build_py
+    python setup.py install
+
+    # now copy the libwx* files from site-packages/wx to lib
+    cp -pr $SP_DIR/wx/libwx* $CONDA_PREFIX/lib/.
+fi

--- a/wxpython-phoenix/meta.yaml
+++ b/wxpython-phoenix/meta.yaml
@@ -1,12 +1,8 @@
 # Note: this recipe simply downloads and installs the binary wheels built by the project.
-#       This means it used statically linked versions of libs that it could get from conda
-
-# There are curretnly only development snapshots available
-{% set version = "3.0.3.dev2832" %}
 
 package:
   name: wxpython-phoenix
-  version:  {{ version }}
+  version: 3.0.3
 
 build:
   number: 0

--- a/wxpython-phoenix/meta.yaml
+++ b/wxpython-phoenix/meta.yaml
@@ -6,16 +6,28 @@ package:
 
 build:
   number: 0
-  script: pip install -U --pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds/linux/gtk2/fedora-24 wxPython_Phoenix # [linux64]
   script: pip install -U --pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds wxPython_Phoenix # [osx or win32 or win64]
 
 requirements:
   build:
     - python
     - setuptools
+    - requests
+    - six
+    - libxml2
+    - libiconv # [linux64]
+    - libgcc >=5.1 # [linux64]
+    - pango >=1.40 # [linux64]
 
   run:
     - python
+    - six
+    - requests
+    - six
+    - libxml2
+    - libiconv # [linux64]
+    - libgcc >=5.1 # [linux64]
+    - pango >=1.40 # [linux64]
 
 test:
     imports:


### PR DESCRIPTION
As in #4, the snapshot binary wheels for linux just don't seem suitable for Anaconda (for example, they are not available for Python3.6). The changes here download the snapshot source kit and builds from that in the Anaconda environment.    I had to make a few hacks to get it to build for me (Fedora 23)

1.  explicitly set gstreamer libs and flags are set.
2. make sure that libiconv is found during the build process.
3. copy libwx*so from site-packages/wx/ to lib/.

I'm not sure I fully understand why these are necessary, but they were necessary for me building on one linux system.

With these changes, I have Anaconda builds wxpython-phoenix for linux-64, osx-64, win-64, and win-32 for both Python2.7 and Python3.6.  These are currently at https://anaconda.org/newville/wxpython-phoenix, for testing.  If that appears to be OK,  we should move the recipes and packages to conda-forge.

